### PR TITLE
Ensure geographies don't go over the antimeridian

### DIFF
--- a/libs/quadkey.js
+++ b/libs/quadkey.js
@@ -270,7 +270,9 @@ locationToQuadkey = function( location, detail ) {
 coords3857ToLongLat = function (x, y) {
 	const world_limit_half = EarthRadius * Math.PI;
 
-	const lng = (x * 180.0) / world_limit_half;
+	/* TODO: When we have a CI, we should test this. A quadkey that used to go slightly over the
+	 * antimeridian was 311131313 */
+	const lng = Math.min(((x * 180.0) / world_limit_half), MaxLongitude);
 	const lat = -90 + 360.0 * Math.atan(Math.exp(Math.PI * (y / world_limit_half))) / Math.PI;
 	return { lng, lat };
 };


### PR DESCRIPTION
Something like 311131313 got a x_max of 180.00000000000003, which is just sligthly
over the antimeridian, so when reading the GeoJSON BQ translated it to ~ -180 which
created a line across the world in the opposite direction of what we want